### PR TITLE
fix: SmallProjectCard tech icons not visible on mobile (#461)

### DIFF
--- a/src/components/LiveProjectCard/LiveProjectCard.tsx
+++ b/src/components/LiveProjectCard/LiveProjectCard.tsx
@@ -4,8 +4,8 @@ import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
 import { cn } from '@/src/utils';
 import IPhoneProFrame from '@/src/components/IPhoneProFrame';
 import LiveProjectIframe from '@/src/components/LiveProjectIframe';
-import { Tooltip } from '@mui/material';
 import { SimpleIcon } from 'simple-icons';
+import { useSimpleIcons } from '@/src/hooks';
 
 export interface LiveProject {
   id: string;
@@ -35,6 +35,10 @@ export default function LiveProjectCard({
   className,
 }: LiveProjectCardProps) {
   const { title, url, fallbackUrl, description, techStack } = project;
+  const { IconContainer } = useSimpleIcons({
+    icons: techStack,
+    size: { mobile: 'md', desktop: 'lg' },
+  });
 
   return (
     <div className={cn('flex flex-col items-center', className)}>
@@ -80,22 +84,7 @@ export default function LiveProjectCard({
             )}
           >
             {/* Tech Stack Icons Row */}
-            <div className="flex justify-center items-center gap-1 mt-2">
-              {techStack.map((tech) => {
-                return (
-                  <Tooltip
-                    key={`tech-stack-${tech.title}`}
-                    title={tech.title}
-                    arrow
-                  >
-                    <div
-                      className="w-6 h-6 flex items-center justify-center fill-white"
-                      dangerouslySetInnerHTML={{ __html: tech.svg }}
-                    />
-                  </Tooltip>
-                );
-              })}
-            </div>
+            <IconContainer className="flex justify-center items-center gap-1 mt-2" />
             {/* Description */}
             <p className="text-secondary text-text-white mt-2">{description}</p>
           </div>

--- a/src/components/LiveProjectCard/LiveProjectCard.tsx
+++ b/src/components/LiveProjectCard/LiveProjectCard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { SimpleIcon } from 'simple-icons';
+
 import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
 import { cn } from '@/src/utils';
+import { useSimpleIcons } from '@/src/hooks';
 import IPhoneProFrame from '@/src/components/IPhoneProFrame';
 import LiveProjectIframe from '@/src/components/LiveProjectIframe';
-import { SimpleIcon } from 'simple-icons';
-import { useSimpleIcons } from '@/src/hooks';
 
 export interface LiveProject {
   id: string;

--- a/src/components/SmallProjectCard/SmallProjectCard.tsx
+++ b/src/components/SmallProjectCard/SmallProjectCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { SimpleIcon } from 'simple-icons';
+
 import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
 import { cn } from '@/src/utils';
 import { useSimpleIcons } from '@/src/hooks';
-import { SimpleIcon } from 'simple-icons';
 
 export interface SmallProject {
   id: string;

--- a/src/components/SmallProjectCard/SmallProjectCard.tsx
+++ b/src/components/SmallProjectCard/SmallProjectCard.tsx
@@ -2,7 +2,7 @@
 
 import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
 import { cn } from '@/src/utils';
-import { Tooltip } from '@mui/material';
+import { useSimpleIcons } from '@/src/hooks';
 import { SimpleIcon } from 'simple-icons';
 
 export interface SmallProject {
@@ -22,10 +22,14 @@ interface SmallProjectCardProps {
  * SmallProjectCard - Compact card for GitHub/smaller projects
  *
  * Structure (from design spec):
- * - Title (h2, Poppins bold italic, white)
+ * - Title (h3, Poppins bold italic, white)
  * - Pill-shaped glassmorphism metadata container
- *   - LEFT: Tech stack icons (24px)
- *   - RIGHT: Description (light italic, Roboto)
+ *   - Mobile (<640px): Icons stacked above description (vertical layout)
+ *   - Desktop (>=640px): Icons LEFT, Description RIGHT (horizontal layout)
+ *
+ * Icon sizing:
+ * - Mobile: 20px (md) for better visibility in narrow containers
+ * - Desktop: 24px (lg) for standard display
  */
 export default function SmallProjectCard({
   project,
@@ -33,31 +37,35 @@ export default function SmallProjectCard({
 }: SmallProjectCardProps) {
   const { title, url, description, techStack } = project;
 
+  const { IconContainer } = useSimpleIcons({
+    icons: techStack,
+    size: { mobile: 'md', desktop: 'lg' },
+  });
+
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
       className={cn('flex flex-col', hoverLiftStyle, className)}
+      aria-label={`View ${title} project on GitHub`}
     >
       {/* Project Title */}
       <h3 className="text-h3 text-text-white">{title}</h3>
 
       {/* Pill-shaped Metadata Container */}
-      <div className={cn('flex items-center gap-3', glassCardBaseStyle)}>
-        {/* Tech Stack Icons - LEFT */}
-        <div className="flex items-center gap-2 shrink-0">
-          {techStack.map((tech) => (
-            <Tooltip key={`tech-${tech.title}`} title={tech.title} arrow>
-              <div
-                className="w-6 h-6 flex items-center justify-center fill-white"
-                dangerouslySetInnerHTML={{ __html: tech.svg }}
-              />
-            </Tooltip>
-          ))}
-        </div>
+      {/* Mobile: vertical stack (icons above description) */}
+      {/* Desktop: horizontal layout (icons left, description right) */}
+      <div
+        className={cn(
+          'flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3',
+          glassCardBaseStyle,
+        )}
+      >
+        {/* Tech Stack Icons */}
+        <IconContainer className="shrink-0" />
 
-        {/* Description - RIGHT */}
+        {/* Description */}
         <p className="text-secondary text-text-white">{description}</p>
       </div>
     </a>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useBreakpoint';
 export * from './useClickOutside';
+export * from './useSimpleIcons';

--- a/src/hooks/useSimpleIcons.tsx
+++ b/src/hooks/useSimpleIcons.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { SimpleIcon } from 'simple-icons';
+import { Tooltip } from '@mui/material';
+import { cn } from '@/src/utils';
+
+/**
+ * Size presets for SimpleIcon rendering
+ * - sm: 16px (mobile compact)
+ * - md: 20px (mobile default)
+ * - lg: 24px (desktop default)
+ */
+type IconSize = 'sm' | 'md' | 'lg';
+
+interface UseSimpleIconsOptions {
+  /** Array of SimpleIcon objects to render */
+  icons: SimpleIcon[];
+  /** Size preset or responsive object */
+  size?: IconSize | { mobile: IconSize; desktop: IconSize };
+  /** Additional className for the icon container */
+  className?: string;
+  /** Show tooltip on hover (default: true) */
+  showTooltip?: boolean;
+  /** Icon color class (default: 'fill-white') */
+  colorClass?: string;
+}
+
+interface RenderedIcon {
+  key: string;
+  title: string;
+  element: React.ReactNode;
+}
+
+interface UseSimpleIconsReturn {
+  /** Array of rendered icon elements with metadata */
+  icons: RenderedIcon[];
+  /** Pre-composed icon container with flex layout */
+  IconContainer: React.FC<{ className?: string }>;
+}
+
+/**
+ * Size mapping to Tailwind classes
+ */
+const sizeClasses: Record<IconSize, string> = {
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-6 h-6',
+};
+
+/**
+ * Responsive size mapping to Tailwind classes
+ */
+const getResponsiveSizeClass = (
+  size: IconSize | { mobile: IconSize; desktop: IconSize },
+): string => {
+  if (typeof size === 'string') {
+    return sizeClasses[size];
+  }
+  // Responsive: mobile size + md: desktop size
+  const mobileClass = sizeClasses[size.mobile];
+  const desktopClass = sizeClasses[size.desktop]
+    .replace('w-', 'md:w-')
+    .replace('h-', 'md:h-');
+  return `${mobileClass} ${desktopClass}`;
+};
+
+/**
+ * useSimpleIcons - Hook for consistent SimpleIcon rendering across components
+ *
+ * Features:
+ * - Responsive sizing (sm/md/lg or mobile/desktop object)
+ * - Consistent color handling with fill-white default
+ * - Optional tooltips for accessibility
+ * - Pre-built IconContainer with responsive flex layout
+ *
+ * @example
+ * ```tsx
+ * const { IconContainer } = useSimpleIcons({
+ *   icons: [siReact, siNextdotjs],
+ *   size: { mobile: 'md', desktop: 'lg' },
+ * });
+ *
+ * return <IconContainer className="justify-center" />;
+ * ```
+ */
+export function useSimpleIcons({
+  icons,
+  size = { mobile: 'md', desktop: 'lg' },
+  className,
+  showTooltip = true,
+  colorClass = 'fill-white',
+}: UseSimpleIconsOptions): UseSimpleIconsReturn {
+  const sizeClass = getResponsiveSizeClass(size);
+
+  const renderedIcons: RenderedIcon[] = icons.map((icon) => {
+    const iconElement = (
+      <div
+        className={cn(
+          'flex items-center justify-center shrink-0',
+          sizeClass,
+          colorClass,
+          className,
+        )}
+        dangerouslySetInnerHTML={{ __html: icon.svg }}
+        aria-label={icon.title}
+        role="img"
+      />
+    );
+
+    const element = showTooltip ? (
+      <Tooltip key={`icon-${icon.slug}`} title={icon.title} arrow>
+        {iconElement}
+      </Tooltip>
+    ) : (
+      <span key={`icon-${icon.slug}`}>{iconElement}</span>
+    );
+
+    return {
+      key: icon.slug,
+      title: icon.title,
+      element,
+    };
+  });
+
+  /**
+   * IconContainer - Pre-built flex container with responsive layout
+   *
+   * Features:
+   * - flex-wrap for mobile overflow handling
+   * - Responsive gap (gap-1.5 on mobile, gap-2 on desktop)
+   * - Centered alignment by default
+   */
+  const IconContainer: React.FC<{ className?: string }> = ({
+    className: containerClassName,
+  }) => (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-1.5 md:gap-2',
+        containerClassName,
+      )}
+      role="list"
+      aria-label="Technologies used"
+    >
+      {renderedIcons.map(({ key, element }) => (
+        <span key={key} role="listitem">
+          {element}
+        </span>
+      ))}
+    </div>
+  );
+
+  return {
+    icons: renderedIcons,
+    IconContainer,
+  };
+}
+
+export type { IconSize, UseSimpleIconsOptions, UseSimpleIconsReturn };


### PR DESCRIPTION
## Summary

Fixes tech stack icons not being visible on mobile viewports in SmallProjectCard. Creates a reusable `useSimpleIcons` hook for consistent icon rendering across the project.

## Changes

### New: `src/hooks/useSimpleIcons.tsx`

A reusable hook for consistent SimpleIcon rendering:

```typescript
const { IconContainer } = useSimpleIcons({
  icons: techStack,
  size: { mobile: 'md', desktop: 'lg' }, // 20px / 24px
  showTooltip: true,
});
```

**Features:**
- Responsive sizing presets: `sm` (16px), `md` (20px), `lg` (24px)
- Mobile/desktop responsive object support
- Built-in `flex-wrap` for overflow handling
- MUI Tooltip integration (optional)
- Accessibility: `aria-label`, `role="img"`, semantic list markup

### Modified: `SmallProjectCard.tsx`

| Before | After |
|--------|-------|
| Horizontal layout always | `flex-col` on mobile, `sm:flex-row` on desktop |
| Fixed 24px icons | 20px mobile, 24px desktop |
| Manual `dangerouslySetInnerHTML` | Uses `useSimpleIcons` hook |
| No flex-wrap | `flex-wrap` prevents overflow |

### Modified: `LiveProjectCard.tsx`

- Updated to use `useSimpleIcons` hook for consistency
- Same responsive sizing pattern as SmallProjectCard

### Export: `src/hooks/index.ts`

- Added `useSimpleIcons` export

## Mobile Fix Details

| Issue | Fix |
|-------|-----|
| Icons not visible on mobile | Responsive sizing (20px mobile, 24px desktop) |
| Flex container overflow | `flex-wrap` in IconContainer |
| Icons competing with text | Vertical stack on mobile (`flex-col sm:flex-row`) |
| Missing fill color | Default `fill-white` in hook |

## Testing

- [x] Lint passing
- [x] Build successful
- [ ] Manual testing on mobile viewport

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)