### PR TITLE
feat(small-project-card): add hashtags and hover preview (#472)

### DIFF
--- a/src/components/SmallProjectCard/SmallProjectCard.tsx
+++ b/src/components/SmallProjectCard/SmallProjectCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import { SimpleIcon } from 'simple-icons';
 
 import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
@@ -7,12 +9,41 @@ import { cn } from '@/src/utils';
 import { useSimpleIcons } from '@/src/hooks';
 import { useTranslations } from 'next-intl';
 
+/**
+ * Tag with optional custom color
+ */
+export interface ProjectTag {
+  label: string;
+  /** Optional custom hex color (default: use TAG_COLORS mapping) */
+  color?: string;
+}
+
 export interface SmallProject {
   id: string;
   title: string;
   url: string;
   techStack: SimpleIcon[];
+  /** Project category/technology tags with color accents */
+  tags?: ProjectTag[];
+  /** URL for hover preview image */
+  previewImage?: string;
 }
+
+/**
+ * Default color mapping for common tag labels
+ * Colors from design spec (Issue #472)
+ */
+export const TAG_COLORS: Record<string, string> = {
+  '#frontend': '#00d4ff', // cyan
+  '#backend': '#10b981', // green
+  '#mobile': '#f59e0b', // amber
+  '#ai/ml': '#c084fc', // purple
+  '#devops': '#ef4444', // red
+  '#iot': '#06b6d4', // teal
+  '#ml': '#c084fc', // purple
+  '#data': '#8b5cf6', // violet
+  '#game': '#ec4899', // pink
+};
 
 interface SmallProjectCardProps {
   project: SmallProject;
@@ -32,16 +63,61 @@ interface SmallProjectCardProps {
  * - Mobile (<768px): 16px (sm) for compact display
  * - Tablet (768-1023px): 20px (md) for intermediate display
  * - Desktop (>=1024px): 24px (lg) for standard display
+ *
+ * New features (Issue #472):
+ * - Color-accented hashtags below tech icons
+ * - Hover-triggered image preview with slide-in animation
  */
 export default function SmallProjectCard({
   project,
   className,
 }: SmallProjectCardProps) {
-  const { id, title, url, techStack } = project;
+  const { id, title, url, techStack, tags, previewImage } = project;
   const projectT = useTranslations('Projects');
   const { IconContainer } = useSimpleIcons({
     icons: techStack,
   });
+
+  // Hover state for preview image
+  const [isHovered, setIsHovered] = useState(false);
+  // Touch device state - tap to reveal preview
+  const [isTapped, setIsTapped] = useState(false);
+  // Track if reduced motion is preferred
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  // Check for reduced motion preference
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setPrefersReducedMotion(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  // Show preview on hover or tap (for touch devices)
+  const showPreview = isHovered || isTapped;
+
+  // Handle touch interaction
+  const handleTouchStart = () => {
+    if (previewImage) {
+      setIsTapped((prev) => !prev);
+    }
+  };
+
+  /**
+   * Get color for a tag label
+   * Priority: custom color > TAG_COLORS mapping > default cyan
+   */
+  const getTagColor = (tag: ProjectTag): string => {
+    if (tag.color) return tag.color;
+    return TAG_COLORS[tag.label.toLowerCase()] || '#00d4ff';
+  };
 
   return (
     <a
@@ -50,6 +126,9 @@ export default function SmallProjectCard({
       rel="noopener noreferrer"
       className={cn('flex flex-col max-sm:w-full', hoverLiftStyle, className)}
       aria-label={`View ${title} project on GitHub`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onTouchStart={handleTouchStart}
     >
       {/* Project Title */}
       <h3 className={'text-h3 md:text-lg text-text-white'}>{title}</h3>
@@ -61,16 +140,77 @@ export default function SmallProjectCard({
         className={cn(
           // Responsive layout: column on mobile, row on tablet+
           'flex flex-col md:flex-col md:items-start gap-2 md:gap-2.5 lg:gap-3',
+          'relative overflow-hidden',
           glassCardBaseStyle,
         )}
       >
-        {/* Tech Stack Icons */}
-        <IconContainer className="shrink-0" />
+        {/* Hover Preview Image - slides in from top */}
+        {previewImage && (
+          <div
+            className={cn(
+              'absolute inset-0 z-10',
+              prefersReducedMotion
+                ? showPreview
+                  ? 'opacity-100'
+                  : 'opacity-0'
+                : 'transition-all duration-300 ease-out',
+              showPreview
+                ? 'translate-y-0 opacity-100'
+                : '-translate-y-full opacity-0',
+            )}
+            aria-hidden={!showPreview}
+          >
+            <Image
+              src={previewImage}
+              alt={`${title} preview`}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              className="object-cover rounded-3xl"
+              loading="lazy"
+            />
+            {/* Gradient overlay for better text readability if needed */}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent rounded-3xl" />
+          </div>
+        )}
 
-        {/* Description */}
-        <p className="text-secondary text-text-white">
-          {projectT(`${id}.desc`)}
-        </p>
+        {/* Content - fades slightly when preview is shown */}
+        <div
+          className={cn(
+            'relative z-0 flex flex-col gap-2 md:gap-2.5 lg:gap-3 w-full',
+            prefersReducedMotion
+              ? ''
+              : 'transition-opacity duration-300 ease-out',
+            showPreview && previewImage ? 'opacity-40' : 'opacity-100',
+          )}
+        >
+          {/* Tech Stack Icons */}
+          <IconContainer className="shrink-0" />
+
+          {/* Hashtags - color-accented tags */}
+          {tags && tags.length > 0 && (
+            <div
+              className="flex flex-wrap gap-1.5 md:gap-2"
+              role="list"
+              aria-label="Project categories"
+            >
+              {tags.map((tag) => (
+                <span
+                  key={tag.label}
+                  role="listitem"
+                  className="text-xs md:text-sm font-medium px-2 py-0.5 rounded-full bg-white/10"
+                  style={{ color: getTagColor(tag) }}
+                >
+                  {tag.label.startsWith('#') ? tag.label : `#${tag.label}`}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Description */}
+          <p className="text-secondary text-text-white">
+            {projectT(`${id}.desc`)}
+          </p>
+        </div>
       </div>
     </a>
   );

--- a/src/components/SmallProjectCard/index.ts
+++ b/src/components/SmallProjectCard/index.ts
@@ -1,2 +1,3 @@
 export { default } from './SmallProjectCard';
-export type { SmallProject } from './SmallProjectCard';
+export { TAG_COLORS } from './SmallProjectCard';
+export type { SmallProject, ProjectTag } from './SmallProjectCard';

--- a/src/components/SmallProjectSection/SmallProjectSection.tsx
+++ b/src/components/SmallProjectSection/SmallProjectSection.tsx
@@ -27,24 +27,32 @@ const projectData: SmallProject[] = [
     title: 'Wink',
     url: 'https://github.com/nordic96/wink',
     techStack: [siIos, siAndroid, siFlutter, siBluetooth],
+    tags: [{ label: '#mobile' }, { label: '#iot' }],
+    previewImage: '/assets/projects/wink-preview.png',
   },
   {
     id: 'temppi',
     title: 'TempPi',
     url: 'https://github.com/nordic96/TempPiApp',
     techStack: [siRaspberrypi, siSpring],
+    tags: [{ label: '#iot' }, { label: '#backend' }],
+    previewImage: '/assets/projects/temppi-preview.png',
   },
   {
     id: 'onion',
     title: 'OnionOrNot',
     url: 'https://github.com/nordic96/OnionOrNot',
     techStack: [siPython, siGooglecolab],
+    tags: [{ label: '#ai/ml' }, { label: '#data' }],
+    previewImage: '/assets/projects/onion-preview.png',
   },
   {
     id: 'covid',
     title: 'Covid19 Chest X-Ray',
     url: 'https://www.youtube.com/watch?v=yVC9sNB-Ucg&list=PLs-H3fc40DvA-mpvdsMi8Yhs3eR6y1kpN&index=7',
     techStack: [siGooglecolab, siPython, siNumpy, siTensorflow],
+    tags: [{ label: '#ai/ml' }, { label: '#data' }],
+    previewImage: '/assets/projects/covid-preview.png',
   },
 ];
 

--- a/src/components/SmallProjectSection/SmallProjectSection.tsx
+++ b/src/components/SmallProjectSection/SmallProjectSection.tsx
@@ -28,7 +28,8 @@ const projectData: SmallProject[] = [
     url: 'https://github.com/nordic96/wink',
     techStack: [siIos, siAndroid, siFlutter, siBluetooth],
     tags: [{ label: '#mobile' }, { label: '#iot' }],
-    previewImage: '/assets/projects/wink-preview.png',
+    previewImage:
+      'https://cdn.jsdelivr.net/gh/nordic96/portfolio_assets/resources/images/wink.png',
   },
   {
     id: 'temppi',
@@ -36,7 +37,8 @@ const projectData: SmallProject[] = [
     url: 'https://github.com/nordic96/TempPiApp',
     techStack: [siRaspberrypi, siSpring],
     tags: [{ label: '#iot' }, { label: '#backend' }],
-    previewImage: '/assets/projects/temppi-preview.png',
+    previewImage:
+      'https://cdn.jsdelivr.net/gh/nordic96/portfolio_assets/resources/images/temppi.gif',
   },
   {
     id: 'onion',
@@ -44,7 +46,8 @@ const projectData: SmallProject[] = [
     url: 'https://github.com/nordic96/OnionOrNot',
     techStack: [siPython, siGooglecolab],
     tags: [{ label: '#ai/ml' }, { label: '#data' }],
-    previewImage: '/assets/projects/onion-preview.png',
+    previewImage:
+      'https://cdn.jsdelivr.net/gh/nordic96/portfolio_assets/resources/images/onion.png',
   },
   {
     id: 'covid',
@@ -52,7 +55,8 @@ const projectData: SmallProject[] = [
     url: 'https://www.youtube.com/watch?v=yVC9sNB-Ucg&list=PLs-H3fc40DvA-mpvdsMi8Yhs3eR6y1kpN&index=7',
     techStack: [siGooglecolab, siPython, siNumpy, siTensorflow],
     tags: [{ label: '#ai/ml' }, { label: '#data' }],
-    previewImage: '/assets/projects/covid-preview.png',
+    previewImage:
+      'https://cdn.jsdelivr.net/gh/nordic96/portfolio_assets/resources/images/covid.png',
   },
 ];
 


### PR DESCRIPTION
## Summary
Enhance the SmallProjectCard component with color-accented hashtags and hover-triggered image previews.

## Changes
- Add `ProjectTag` interface with label and optional custom color
- Implement `TAG_COLORS` mapping for common categories (frontend, backend, mobile, ai/ml, devops, iot, data, game)
- Add color-accented hashtags below tech stack icons with pill styling
- Implement hover-triggered image preview with slide-in animation
- Add touch device support with tap to reveal/hide preview
- Respect `prefers-reduced-motion` preference for accessibility
- Use Next.js Image component for optimized preview loading
- Add gradient overlay on preview for text readability
- Update SmallProjectSection with sample tags and preview images

## Files Changed
| File | Changes |
|------|---------|
| `SmallProjectCard.tsx` | +147 lines - hashtags + hover preview implementation |
| `SmallProjectCard/index.ts` | Export TAG_COLORS and ProjectTag |
| `SmallProjectSection.tsx` | Sample data with tags and preview images |

## Checklist
- [x] Lint passing
- [x] Build successful
- [x] Accessibility (prefers-reduced-motion)
- [x] Touch device support
- [ ] Manual testing
- [ ] Add actual preview images to `/public/assets/projects/`

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)