### PR TITLE
Mobile UI Support with Updated Locales

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,7 @@
         "github_label": "Visit Stephen's GitHub profile (opens in new tab)"
     },
     "MetadataSection": {
-        "spotify_top_artists": "My Top Artists on Spotify",
+        "spotify_top_artists": "My Top Artists provided by Spotify",
         "currently_reading": "Currently Reading",
         "completed_reading": "Completed Reading"
     },
@@ -82,5 +82,9 @@
     "SandBoxPage": {
         "header": "Welcome to my secret sandbox page! nothing serious here, just displaying some new cool techniques or frontend concepts that I wanted to do hands-on freely!",
         "btn_back_to_homepage": "Back To HomePage"
+    },
+    "TopTracksSection": {
+        "header": "My Top #8 Tracks",
+        "disclaimer": "Tracks & Artist data provided by Spotify"
     }
 }

--- a/src/app/[locale]/sandbox/CircleItem.tsx
+++ b/src/app/[locale]/sandbox/CircleItem.tsx
@@ -25,7 +25,7 @@ export default function CircleItem({
           src={src || ''}
           loading={'eager'}
           className={
-            'w-40 h-40 max-sm:w-30 max-sm:h-30 rounded-full object-cover'
+            'w-40 h-40 max-sm:w-20 max-sm:h-20 rounded-full object-cover'
           }
           width={100}
           height={100}
@@ -34,7 +34,7 @@ export default function CircleItem({
       <span
         className={cn(
           glassCardBaseStyle,
-          'whitespace-pre-line text-center max-w-45',
+          'whitespace-pre-line text-center max-w-45 max-sm:text-xs max-sm:p-1',
           'absolute bottom-[-20]',
         )}
       >

--- a/src/app/[locale]/sandbox/page.tsx
+++ b/src/app/[locale]/sandbox/page.tsx
@@ -74,7 +74,12 @@ export default function Page() {
       }
     >
       {/** Left Outer Circle Container */}
-      <div className={'z-0 absolute left-[5%] top-125'}>
+      <div
+        className={cn(
+          'z-0 absolute left-[5%]',
+          isMobile ? 'bottom-50' : 'top-125',
+        )}
+      >
         {/** Books Outer Circle Container */}
         <div
           className={cn(
@@ -156,7 +161,7 @@ export default function Page() {
           <h2 className={'text-3xl font-semibold'}>SANDBOX PAGE</h2>
           <p>{t('header')}</p>
         </div>
-        <div className={'mt-4'}>
+        <div className={'mt-4 w-fit'}>
           <Link href={'/'}>
             <PrimaryButton>
               <ArrowBack />

--- a/src/app/[locale]/sandbox/page.tsx
+++ b/src/app/[locale]/sandbox/page.tsx
@@ -11,8 +11,17 @@ import PrimaryButton from '@/src/components/shared/PrimaryButton';
 import { ArrowBack } from '@mui/icons-material';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
+import { useBreakpoint } from '@/src/hooks';
+import {
+  BOOK_CIRCLE_MOBILE_STYLE,
+  BOOK_CIRCLE_STYLE,
+  CircularTextOptions,
+  DESKTOP_CIRCLE_STYLE,
+  MOBILE_CIRCLE_STYLE,
+} from '@/src/components/CircularText/CircularText';
 
 export default function Page() {
+  const isMobile = useBreakpoint() === 'mobile';
   const locale = useLocale();
   const t = useTranslations('SandBoxPage');
   const [artistText, setArtistText] = useState('');
@@ -45,6 +54,16 @@ export default function Page() {
     setBookText(constructedText);
   }, [books]);
 
+  const getArtistCircleStyleByBreakpoint = (): CircularTextOptions => {
+    if (isMobile) return MOBILE_CIRCLE_STYLE;
+    return DESKTOP_CIRCLE_STYLE;
+  };
+
+  const getBookCircleStyleByBreakpoint = (): CircularTextOptions => {
+    if (isMobile) return BOOK_CIRCLE_MOBILE_STYLE;
+    return BOOK_CIRCLE_STYLE;
+  };
+
   const positionCentreStyle =
     'absolute top-[50%] translate-y-[-50%] left-[50%] translate-x-[-50%]';
 
@@ -61,7 +80,8 @@ export default function Page() {
           className={cn(
             positionCentreStyle,
             'animate-spin [animation-duration:50s]',
-            'circle-container book-circle',
+            isMobile ? 'book-circle-mobile' : 'book-circle',
+            'circle-container',
           )}
         >
           {loadingBooks &&
@@ -91,7 +111,7 @@ export default function Page() {
         <div className={cn(positionCentreStyle)}>
           <CircularText
             text={bookText}
-            options={{ width: 650, height: 650, fontSize: 48 }}
+            options={getBookCircleStyleByBreakpoint()}
           />
         </div>
       </div>
@@ -101,18 +121,15 @@ export default function Page() {
         <div className={cn(positionCentreStyle)}>
           <CircularText
             text={artistText}
-            options={{
-              width: 900,
-              height: 900,
-              fontSize: 40,
-            }}
+            options={getArtistCircleStyleByBreakpoint()}
           />
         </div>
         {/** Spotify Top Artists Inner Circle */}
         <div
           className={cn(
             'animate-spin [animation-duration:50s]',
-            'circle-container artist-circle',
+            'circle-container',
+            isMobile ? 'artist-circle-mobile' : 'artist-circle',
             positionCentreStyle,
           )}
         >
@@ -134,18 +151,23 @@ export default function Page() {
         </div>
       </div>
       {/** Back To Home Page Btn Container */}
-      <div className={'absolute top-0 left-0 w-full z-20'}>
+      <div
+        className={cn(
+          'absolute top-0 left-0 w-full z-20',
+          'px-4 md:px-6 lg:px-8',
+        )}
+      >
         <div className={'max-w-200'}>
           <h2 className={'text-3xl font-semibold'}>SANDBOX PAGE</h2>
           <p>{t('header')}</p>
         </div>
         <div className={'mt-4'}>
-          <PrimaryButton>
-            <Link href={'/'}>
+          <Link href={'/'}>
+            <PrimaryButton>
               <ArrowBack />
               {t('btn_back_to_homepage')}
-            </Link>
-          </PrimaryButton>
+            </PrimaryButton>
+          </Link>
         </div>
         <div className={'flex justify-center items-center'}>
           <TopTracksSection />

--- a/src/app/[locale]/sandbox/page.tsx
+++ b/src/app/[locale]/sandbox/page.tsx
@@ -89,7 +89,7 @@ export default function Page() {
               return (
                 <div
                   key={`book-loading-${i}`}
-                  className={'flex flex-col items-center'}
+                  className={'flex flex-col items-center min-w-75'}
                 >
                   <Skeleton variant={'circular'} width={160} height={160} />
                   <Skeleton variant={'text'} width={120} />
@@ -151,12 +151,7 @@ export default function Page() {
         </div>
       </div>
       {/** Back To Home Page Btn Container */}
-      <div
-        className={cn(
-          'absolute top-0 left-0 w-full z-20',
-          'px-4 md:px-6 lg:px-8',
-        )}
-      >
+      <div className={cn('absolute top-0 left-0 w-full z-20', 'max-sm:px-4')}>
         <div className={'max-w-200'}>
           <h2 className={'text-3xl font-semibold'}>SANDBOX PAGE</h2>
           <p>{t('header')}</p>
@@ -169,7 +164,7 @@ export default function Page() {
             </PrimaryButton>
           </Link>
         </div>
-        <div className={'flex justify-center items-center'}>
+        <div className={'flex justify-center items-center mt-8'}>
           <TopTracksSection />
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -535,7 +535,14 @@ body {
   offset: circle(200px) calc(100% * sibling-index()/sibling-count()) 0deg;
 }
 
+.book-circle-mobile > div {
+  offset: circle(100px) calc(100% * sibling-index()/sibling-count()) 0deg;
+}
 
 .artist-circle > div {
   offset: circle(550px) calc(100% * sibling-index()/sibling-count()) 0deg;
+}
+
+.artist-circle-mobile > div {
+  offset: circle(270px) calc(100% * sibling-index()/sibling-count()) 0deg;
 }

--- a/src/components/CircularText/CircularText.tsx
+++ b/src/components/CircularText/CircularText.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/src/utils';
 import { useId } from 'react';
 
-type CircularTextOptions = {
+export type CircularTextOptions = {
   width?: number;
   height?: number;
   fontSize?: number;
@@ -11,6 +11,30 @@ type CircularTextOptions = {
 type CircularTextProps = {
   text: string;
   options: CircularTextOptions;
+};
+
+export const BOOK_CIRCLE_STYLE: CircularTextOptions = {
+  width: 650,
+  height: 650,
+  fontSize: 48,
+};
+
+export const BOOK_CIRCLE_MOBILE_STYLE: CircularTextOptions = {
+  width: 325,
+  height: 325,
+  fontSize: 16,
+};
+
+export const MOBILE_CIRCLE_STYLE: CircularTextOptions = {
+  width: 450,
+  height: 450,
+  fontSize: 16,
+};
+
+export const DESKTOP_CIRCLE_STYLE: CircularTextOptions = {
+  width: 900,
+  height: 900,
+  fontSize: 40,
 };
 
 export default function CircularText({ text, options }: CircularTextProps) {

--- a/src/components/MetadataSection/MetadataSection.tsx
+++ b/src/components/MetadataSection/MetadataSection.tsx
@@ -30,12 +30,14 @@ interface ArtistBubbleProps {
   artist: Artist;
 }
 function ArtistBubble({ artist }: ArtistBubbleProps) {
-  const { name, images } = artist;
+  const { name, images, external_urls } = artist;
   const img = images[0];
   return (
     <div className={'flex flex-col items-center gap-1'}>
       {img && (
-        <div
+        <a
+          target={'_blank'}
+          href={external_urls.spotify}
           className={
             'overflow-hidden rounded-full transition-transform duration-300 hover:scale-120'
           }
@@ -47,7 +49,7 @@ function ArtistBubble({ artist }: ArtistBubbleProps) {
             height={56}
             width={56}
           />
-        </div>
+        </a>
       )}
       <p className={'max-w-16 text-center'}>{name}</p>
     </div>
@@ -68,6 +70,7 @@ export default function MetadataSection() {
 
   const { IconContainer: SpotifyIcon } = useSimpleIcons({
     icons: [siSpotify],
+    fillOriginalColour: true,
     className: {
       'lg:w-7 lg:h-7': true,
     },
@@ -86,7 +89,7 @@ export default function MetadataSection() {
       <div>
         <div className={'flex gap-2 items-center'}>
           <SpotifyIcon />
-          <p>{t('spotify_top_artists')}</p>
+          <span>{t('spotify_top_artists')}</span>
         </div>
         <div
           ref={containerRef}

--- a/src/components/TopTracksSection/TopTracksSection.tsx
+++ b/src/components/TopTracksSection/TopTracksSection.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 import { glassCardBaseStyle, hoverLiftStyle } from '@/src/styles';
 import { cn } from '@/src/utils';
 import { Track } from '@/src/types';
+import { Refresh } from '@mui/icons-material';
+import { Skeleton } from '@mui/material';
 
 function TrackCard({ track, rank }: { track: Track; rank: number }) {
   const { name, album } = track;
@@ -14,7 +16,7 @@ function TrackCard({ track, rank }: { track: Track; rank: number }) {
     <div
       className={cn(
         glassCardBaseStyle,
-        'flex gap-2 items-center',
+        'flex gap-2 items-center max-sm:p-2!',
         hoverLiftStyle,
       )}
     >
@@ -36,7 +38,7 @@ function TrackCard({ track, rank }: { track: Track; rank: number }) {
 }
 
 export default function TopTracksSection() {
-  const { tracks, fetchTracks } = useSpotifyStore();
+  const { tracks, fetchTracks, loadingTracks } = useSpotifyStore();
   const { containerRef, getItemClassName } =
     useStaggeredAnimation<HTMLDivElement>({
       itemCount: ARTISTS_TO_FETCH,
@@ -48,12 +50,47 @@ export default function TopTracksSection() {
   }, [fetchTracks]);
 
   return (
-    <div ref={containerRef} className={'flex flex-col gap-4'}>
-      {tracks.map((track, i) => (
-        <div key={track.id} className={getItemClassName(i)}>
-          <TrackCard rank={i + 1} track={track} />
-        </div>
-      ))}
+    <div>
+      <div className={'flex gap-4 items-center'}>
+        <h3 className={'text-2xl font-semibold'}>My Top #8 Tracks</h3>
+        <button
+          onClick={fetchTracks}
+          disabled={loadingTracks}
+          className={cn(
+            loadingTracks ? 'animate-spin' : '',
+            'p-0.5 rounded-full bg-[#1ED760]',
+            'cursor-pointer',
+            'disabled:bg-gray-400',
+          )}
+        >
+          <Refresh fontSize={'medium'} sx={{ color: '#000' }} />
+        </button>
+      </div>
+      <div ref={containerRef} className={'flex flex-col gap-4 mt-4'}>
+        {loadingTracks &&
+          new Array(5).fill(1).map((x, i) => {
+            return (
+              <div
+                key={`track-loading-skeleton-${i}`}
+                className={cn(glassCardBaseStyle, 'flex gap-2 items-center')}
+              >
+                <div className={'w-15 h-15'}>
+                  <Skeleton width={50} height={50} variant={'circular'} />
+                </div>
+                <div className={'w-full'}>
+                  <Skeleton variant={'text'} />
+                  <Skeleton variant={'text'} />
+                </div>
+              </div>
+            );
+          })}
+        {!loadingTracks &&
+          tracks.map((track, i) => (
+            <div key={track.id} className={getItemClassName(i)}>
+              <TrackCard rank={i + 1} track={track} />
+            </div>
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/TopTracksSection/TopTracksSection.tsx
+++ b/src/components/TopTracksSection/TopTracksSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useStaggeredAnimation } from '@/src/hooks';
+import { useSimpleIcons, useStaggeredAnimation } from '@/src/hooks';
 import { ARTISTS_TO_FETCH, useSpotifyStore } from '@/src/store';
 import { useEffect } from 'react';
 import Image from 'next/image';
@@ -9,11 +9,15 @@ import { cn } from '@/src/utils';
 import { Track } from '@/src/types';
 import { Refresh } from '@mui/icons-material';
 import { Skeleton } from '@mui/material';
+import { siSpotify } from 'simple-icons';
+import { useTranslations } from 'next-intl';
 
 function TrackCard({ track, rank }: { track: Track; rank: number }) {
-  const { name, album } = track;
+  const { name, album, external_urls } = track;
   return (
-    <div
+    <a
+      target={'_blank'}
+      href={external_urls.spotify}
       className={cn(
         glassCardBaseStyle,
         'flex gap-2 items-center max-sm:p-2!',
@@ -33,11 +37,16 @@ function TrackCard({ track, rank }: { track: Track; rank: number }) {
         >{`#${rank}. ${name}`}</span>
         <span>{album.artists[0].name}</span>
       </div>
-    </div>
+    </a>
   );
 }
 
 export default function TopTracksSection() {
+  const t = useTranslations('TopTracksSection');
+  const { IconContainer } = useSimpleIcons({
+    icons: [siSpotify],
+    fillOriginalColour: true,
+  });
   const { tracks, fetchTracks, loadingTracks } = useSpotifyStore();
   const { containerRef, getItemClassName } =
     useStaggeredAnimation<HTMLDivElement>({
@@ -51,8 +60,14 @@ export default function TopTracksSection() {
 
   return (
     <div>
-      <div className={'flex gap-4 items-center'}>
-        <h3 className={'text-2xl font-semibold'}>My Top #8 Tracks</h3>
+      <div className={'flex gap-4 items-center justify-between'}>
+        <div className={'flex flex-col gap-2'}>
+          <h3 className={'text-2xl font-semibold'}>{t('header')}</h3>
+          <div className={'flex items-center gap-2'}>
+            <IconContainer />
+            <span>{t('disclaimer')}</span>
+          </div>
+        </div>
         <button
           onClick={fetchTracks}
           disabled={loadingTracks}

--- a/src/hooks/useSimpleIcons.tsx
+++ b/src/hooks/useSimpleIcons.tsx
@@ -21,6 +21,8 @@ interface UseSimpleIconsOptions {
   showTooltip?: boolean;
   /** Icon color class (default: 'fill-white') */
   colorClass?: string;
+  /** Fill SVG with original colour hexcode (default: false) */
+  fillOriginalColour?: boolean;
 }
 
 interface RenderedIcon {
@@ -59,6 +61,7 @@ export function useSimpleIcons({
   icons,
   className,
   showTooltip = true,
+  fillOriginalColour = false,
   colorClass = 'fill-white',
 }: UseSimpleIconsOptions): UseSimpleIconsReturn {
   const renderedIcons: RenderedIcon[] = useMemo(
@@ -67,20 +70,21 @@ export function useSimpleIcons({
         const iconElement = (
           <div
             className={cn(
+              colorClass,
+              className,
               'flex items-center justify-center shrink-0',
               {
                 'max-sm:w-4 max-sm:h-4': true,
                 'md:w-5 md:h-5': true,
                 'lg:w-6 lg:h-6': true,
               },
-              colorClass,
-              className,
             )}
             /**
              * SAFETY: SVG content from 'simple-icons' package (trusted source).
              * No user input involved. Static SVG strings only.
              */
             dangerouslySetInnerHTML={{ __html: icon.svg }}
+            style={fillOriginalColour ? { fill: `#${icon.hex}` } : undefined}
             aria-label={icon.title}
             role="img"
           />
@@ -100,7 +104,7 @@ export function useSimpleIcons({
           element,
         };
       }),
-    [icons, className, showTooltip, colorClass],
+    [icons, className, showTooltip, colorClass, fillOriginalColour],
   );
 
   /**

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -2,6 +2,7 @@ import { hasLocale } from 'next-intl';
 import { getRequestConfig } from 'next-intl/server';
 import { routing } from './routing';
 import { CDN_BASE } from '../config';
+import backupMessageData from '../../messages/en.json';
 
 /**
  * Will fetch locale json file from CDN, if error or not found, will return backup defualt en locale file (/messages/en.json)
@@ -9,6 +10,13 @@ import { CDN_BASE } from '../config';
  * @returns Locale File JSON
  */
 export async function geti18nConfig(locale: string) {
+  /** Return Offline Locale for Development Use Case */
+  if (process.env.USE_BACKUP_LOCALE === 'true') {
+    return {
+      locale,
+      messages: backupMessageData,
+    };
+  }
   const cdnUrl = new URL(`${CDN_BASE}/resources/messages/${locale}.json`);
   let messages;
   try {

--- a/src/store/useSpotifyStore.ts
+++ b/src/store/useSpotifyStore.ts
@@ -7,9 +7,11 @@ export const TRACKS_TO_FETCH = 8;
 
 type State = {
   loading: boolean;
+  loadingTracks: boolean;
   artists: Artist[];
   tracks: Track[];
   error: Error | null;
+  errorTracks: Error | null;
 };
 
 type Actions = {
@@ -24,9 +26,11 @@ export const useSpotifyStore = create<SpotifyState>()(
   persist(
     (set) => ({
       loading: false,
+      loadingTracks: false,
       artists: [],
       tracks: [],
       error: null,
+      errorTracks: null,
       fetchArtists: async () => {
         try {
           if (controller !== null) {
@@ -60,6 +64,7 @@ export const useSpotifyStore = create<SpotifyState>()(
             trackRequestController.abort();
           }
           trackRequestController = new AbortController();
+          set(() => ({ loadingTracks: true, errorTracks: null }));
           const res = await fetch('/api/v1/spotify/top-tracks', {
             signal: trackRequestController.signal,
           });
@@ -72,11 +77,11 @@ export const useSpotifyStore = create<SpotifyState>()(
           }
         } catch (e) {
           if (e instanceof Error) {
-            set(() => ({ error: e }));
+            set(() => ({ errorTracks: e }));
           }
         } finally {
           controller = null;
-          set(() => ({ loading: false }));
+          set(() => ({ loadingTracks: false }));
         }
       },
     }),


### PR DESCRIPTION
* CircleItem UI Component
* CircularText UI Component
* Mobile css support in globals.css
* fixed unintended single usage of loading and error state vars in useSpotifyStore for tracks and artists data
* added fillOriginColour SimpleIconsOptions
* added loading skeleton for top tracks UI component
* laouts updates in sandbox main page

### Adjusted Spotify Logos with Disclaimers
* introduced USE_BACKUP_LOCALE env var for using backup locales in dev mode
* updated backup messages/en.json with new TopTracksSection locales
* TopTracksSection added disclaimer with original colour in spotify icons with tracks links to spotify urls
* Updated MetadataSection to fill original colour for Spotify icon and wrapped ArtistBubble component with links to spotify urls